### PR TITLE
Patch 2023

### DIFF
--- a/lesson-2-sli-slo/exercises/starter/README.md
+++ b/lesson-2-sli-slo/exercises/starter/README.md
@@ -47,7 +47,7 @@
 
     `helm repo add prometheus-community https://prometheus-community.github.io/helm-charts`
 
-    `helm install prometheus prometheus-community/kube-prometheus-stack -f "values.yaml" --namespace monitoring`
+    `helm install prometheus prometheus-community/kube-prometheus-stack -f "values.yaml" --namespace monitoring --version 40.0.0`
 
 Get the DNS of your load balancer provisioned to access Prometheus. You can find this by opening your AWS console and going to EC2 -> Load Balancers and selecting the load balancer provisioned. The DNS name of it will be listed below that you can copy and paste into your browser. Copy that into your web browser with the port `:9090` appended to access Prometheus. It will look something like this:
 `ab8ec64a7ad1d4a03b4c8039511bb2c6-3e6b8d197cd16333.elb.us-east-2.amazonaws.com:9090`

--- a/lesson-2-sli-slo/exercises/starter/main.tf
+++ b/lesson-2-sli-slo/exercises/starter/main.tf
@@ -3,10 +3,7 @@ locals {
 
    name   = "udacity"
    region = "us-east-2"
-   tags = {
-     Name      = local.name
-     Terraform = "true"
-   }
+   tags = {}
  }
 
  module "vpc" {

--- a/lesson-2-sli-slo/exercises/starter/modules/eks/eks.tf
+++ b/lesson-2-sli-slo/exercises/starter/modules/eks/eks.tf
@@ -22,7 +22,7 @@ resource "aws_security_group" "eks-cluster" {
 }
 resource "aws_eks_cluster" "cluster" {
    name     = "${var.name}-cluster"
-   version  = "1.21"
+   version  = "1.23"
    role_arn = aws_iam_role.eks_cluster_role.arn
 
    vpc_config {

--- a/lesson-2-sli-slo/exercises/starter/values.yaml
+++ b/lesson-2-sli-slo/exercises/starter/values.yaml
@@ -1368,8 +1368,8 @@ prometheusOperator:
     patch:
       enabled: true
       image:
-        repository: jettech/kube-webhook-certgen
-        tag: v1.5.2
+        repository: k8s.gcr.io/ingress-nginx/kube-webhook-certgen
+        tag: v1.3.0
         sha: ""
         pullPolicy: IfNotPresent
       resources: {}


### PR DESCRIPTION
This patch will make lesson 2 runnable (at least in 2023). Here is the change list:

- Specify older version of kube-prometheus-stack helm chart to 40.0.0 (not working since 42.x)
- Remove all default tags of aws resources (udacity-provided credential does not have iam:TagPolicy permission)
- Change EKS cluster version to 1.23 (version 1.21 is EOL)
- Change admission webhook patch image in prometheus stack (old image does not work anymore)